### PR TITLE
feat: support full palette from llava

### DIFF
--- a/matugen-llava-seed/src/matugen.rs
+++ b/matugen-llava-seed/src/matugen.rs
@@ -3,11 +3,14 @@ use anyhow::{anyhow, Result};
 use std::path::Path;
 use std::process::Command;
 
-pub fn run_from_color(cfg: &Config, seed: &str, mode: &str, dry_run: bool) -> Result<()> {
-    let mut args = cfg.matugen.args_color.clone();
-    args.push(seed.to_string());
-    args.extend(cfg.matugen.extra_args.clone());
-    run_matugen(args, mode, dry_run)
+pub fn run_from_colors(cfg: &Config, seeds: &[String], mode: &str, dry_run: bool) -> Result<()> {
+    for seed in seeds {
+        let mut args = cfg.matugen.args_color.clone();
+        args.push(seed.to_string());
+        args.extend(cfg.matugen.extra_args.clone());
+        run_matugen(args, mode, dry_run)?;
+    }
+    Ok(())
 }
 
 pub fn run_from_image(cfg: &Config, image: &Path, mode: &str, dry_run: bool) -> Result<()> {

--- a/matugen-llava-seed/tests/basic.rs
+++ b/matugen-llava-seed/tests/basic.rs
@@ -1,10 +1,21 @@
 use assert_cmd::Command;
 use matugen_llava_seed::utils::{validate_hex, decide_mode};
+use matugen_llava_seed::llava::parse_palette;
 
 #[test]
 fn test_hex_validator() {
     assert!(validate_hex("#A1B2C3"));
     assert!(!validate_hex("123456"));
+}
+
+#[test]
+fn test_parse_palette() {
+    let json = "{\"primary_hex\":\"#AABBCC\",\"secondary_hex\":\"#112233\",\"tertiary_hex\":\"#445566\",\"accent1_hex\":\"#778899\",\"accent2_hex\":\"#ABCDEF\",\"neutral1_hex\":\"#123456\",\"neutral2_hex\":\"#654321\"}";
+    let palette = parse_palette(json).expect("palette");
+    assert_eq!(palette.len(), 7);
+    for color in palette.values() {
+        assert!(validate_hex(color));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- ask llava for a full Material-You style palette
- parse and cache multiple colors instead of a single seed
- feed each color to Matugen when applying themes

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6899b7c7cbf88321a16e19954d91aa06